### PR TITLE
App labels and separators

### DIFF
--- a/Tweak.h
+++ b/Tweak.h
@@ -82,6 +82,10 @@
 @property (nonatomic, assign, readwrite, getter=isHidden) BOOL hidden;
 @end
 
+@interface _UIInterfaceActionBlankSeparatorView
+@property (nonatomic, assign, readwrite, getter=isHidden) BOOL hidden;
+@end
+
 @interface SBFluidSwitcherItemContainerHeaderView
 @property (nonatomic, assign, readwrite, getter=isHidden) BOOL hidden;
 @end
@@ -173,7 +177,7 @@
 @interface SBIconListPageControl
 @end
 
-@interface SBMutableIconLabelImageParameters
+@interface SBIconView : UIView
 @end
 
 @interface TFNItemsDataViewController : NSObject

--- a/Tweak.xm
+++ b/Tweak.xm
@@ -45,7 +45,7 @@ NSString *carrierName;
 	}
 
 	if (dockbackground) {
-		UIView *bgView = MSHookIvar<UIView *>(self, "_backgroundView"); 
+		UIView *bgView = MSHookIvar<UIView *>(self, "_backgroundView");
 		bgView.alpha = 0;
 		bgView.hidden = YES;
 	}
@@ -329,6 +329,13 @@ NSString *carrierName;
 		self.hidden = YES;
 }
 %end
+%hook _UIInterfaceActionBlankSeparatorView
+- (void)layoutSubviews{
+	%orig;
+	if(separator)
+		self.hidden = YES;
+}
+%end
 
 // NoWidgetFooter
 %hook WGWidgetListFooterView
@@ -428,12 +435,12 @@ NSString *carrierName;
 }
 %end
 
-// NoAppLabels
-%hook SBMutableIconLabelImageParameters
--(void)setTextColor:(id)arg1{
+// NoAppLabels (inspired from anynon/HideLabels13)
+%hook SBIconView
+- (void)setLabelHidden:(BOOL)arg1 {
 	%orig;
 	if(applabels)
-		%orig([UIColor clearColor]);
+		%orig(YES);
 }
 %end
 
@@ -483,7 +490,7 @@ NSString *carrierName;
 - (id)tableViewCellForItem:(id)arg1 atIndexPath:(id)arg2{
 	UITableViewCell *tbvCell = %orig;
 	id item = [self itemAtIndexPath: arg2];
-	return tbvCell;  
+	return tbvCell;
 	if([item respondsToSelector: @selector(isPromoted)] && [item performSelector:@selector(isPromoted)] && twitterads)
 		[tbvCell setHidden: YES];
 }
@@ -499,7 +506,7 @@ NSString *carrierName;
 // NoRedditAds
 %hook Post
 - (bool)isHidden{
-	return %orig;  
+	return %orig;
 	if([NSStringFromClass([self classForCoder]) isEqual:@"AdPost"] && redditads) {
 		return YES;
 	}


### PR DESCRIPTION
Hi, thanks for making this tweak!
This PR fixes these things (Check out the images if my explanations aren't clear):
- When "Hide App Labels" is enabled, the screen time hourglass isn't centered.
- When "Hide Separators Lines" is enabled, and you 3d touch an app icon, a large separator is still present.

Images: 
https://drive.google.com/file/d/1uVenlVL4giLMzBi1JccLvCvHMfOj0yMO/view?usp=sharing
https://drive.google.com/file/d/1oDRZm9hVTSD3gu1HIQD-PP_sDDSQyNxw/view?usp=sharing